### PR TITLE
Returning NotFound error on MedeaIterator when value is undefined.

### DIFF
--- a/medeaiterator.js
+++ b/medeaiterator.js
@@ -26,6 +26,9 @@ MedeaIterator.prototype._next = function (callback) {
   this.idx++
 
   this.db.get(key, this.snapshot, function (err, value) {
+    if (!err && value === undefined)
+      err = new Error('NotFound:')
+
     if (err)
       return callback(err)
 

--- a/test.js
+++ b/test.js
@@ -65,6 +65,27 @@ test('iterator on previously closed db', function (t) {
   })
 })
 
+test('iterator on previously closed db with deleted key', function (t) {
+  var location = db.location
+
+  db.put('beep', 'boop', function () {
+    db.del('beep', function() {
+      db.close(function () {
+        db = medeaDOWN(location)
+        db.open(function () {
+          var iterator = db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
+
+          iterator.next(function (err, key, value) {
+            t.equal(err.message, 'NotFound:')
+            iterator.end(t.end.bind(t))
+          })
+
+        })
+      })
+    })
+  })
+})
+
 test('tearDown', function (t) {
   db.close(testCommon.tearDown.bind(null, t))
 })


### PR DESCRIPTION
Steps to reproduce bug:
1. Put key-value pair.
2. Delete key.
3. Close database.
4. Open database.
5. Run iterator via `db.createReadStream()`.

In Medea, after an initial load of the keydir, we don't know if a value has been tombstoned, so we load all keys in the keydir.  We only find out when retrieving the value if it has been tombstoned, and then we return an undefined value in the `get` response.  The MedeaIterator was not taking this scenario into consideration.  It has been updated accordingly.
