### PR TITLE
Fixing iterator behavior to match LevelDOWN... 

### DIFF
--- a/medeaiterator.js
+++ b/medeaiterator.js
@@ -27,7 +27,7 @@ MedeaIterator.prototype._next = function (callback) {
 
   this.db.get(key, this.snapshot, function (err, value) {
     if (!err && value === undefined)
-      err = new Error('NotFound:')
+      return self._next(callback)
 
     if (err)
       return callback(err)

--- a/test.js
+++ b/test.js
@@ -76,7 +76,9 @@ test('iterator on previously closed db with deleted key', function (t) {
           var iterator = db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
 
           iterator.next(function (err, key, value) {
-            t.equal(err.message, 'NotFound:')
+            t.notOk(err)
+            t.notOk(key)
+            t.notOk(value)
             iterator.end(t.end.bind(t))
           })
 


### PR DESCRIPTION
...when iterating over a Medea entry that has been tombstoned.

This fixes a bug introduced in #4.  The behavior was not implemented in a way that matches LevelDOWN.
